### PR TITLE
Call -[super layout]

### DIFF
--- a/FsprgEmbeddedStore/FsprgOrderView.m
+++ b/FsprgEmbeddedStore/FsprgOrderView.m
@@ -73,6 +73,7 @@
 		NSView *newSubview = [[delegate delegate] viewWithFrame:[self frame] forOrder:order];
 		[self addSubview:newSubview];
 	}
+	[super layout];
 }
 
 - (void)viewDidMoveToHostWindow


### PR DESCRIPTION
Auto Layout requires that any implementation of -layout must call supers implementation.

For now, cocoa only logs the following warning to the console:

> Layout still needs update after calling -[FsprgOrderView layout].  FsprgOrderView or one of its superclasses may have overridden -layout without calling super. Or, something may have dirtied layout in the middle of updating it.  Both are programming errors in Cocoa Autolayout.  The former is pretty likely to arise if some pre-Cocoa Autolayout class had a method called layout, but it should be fixed.

But this may change in a future OS release…
