### PR TITLE
Fixed crash on 10.7 and warning

### DIFF
--- a/FsprgEmbeddedStore/FsprgEmbeddedStoreController.m
+++ b/FsprgEmbeddedStore/FsprgEmbeddedStoreController.m
@@ -386,7 +386,7 @@
 
     NSMutableArray *certificates = [NSMutableArray arrayWithCapacity:count];
 	CFIndex idx;
-	for (idx = 0; idx < count; idx++) {
+	for (idx = 0; idx < (CFIndex)count; idx++) {
 		SecCertificateRef certificateRef = SecTrustGetCertificateAtIndex(trustRef, idx);
 		[certificates addObject:(id)certificateRef];
 	}


### PR DESCRIPTION
Embedded store was crashing on 10.7 when using the 10.8 SDK.
Silenced a warning.
