### PR TITLE
Pass -webView:didStartProvisionalLoadForFrame: to store delegate

### DIFF
--- a/FsprgEmbeddedStore/FsprgEmbeddedStoreController.m
+++ b/FsprgEmbeddedStore/FsprgEmbeddedStoreController.m
@@ -240,6 +240,9 @@
 
 - (void)webView:(WebView *)sender didStartProvisionalLoadForFrame:(WebFrame *)frame
 {
+    if ([[self delegate] respondsToSelector:@selector(webView:didStartProvisionalLoadForFrame:)]) {
+        [[self delegate] webView:sender didStartProvisionalLoadForFrame:frame];
+    }
 }
 
 - (void)webView:(WebView *)sender didFinishLoadForFrame:(WebFrame *)frame

--- a/FsprgEmbeddedStore/FsprgEmbeddedStoreDelegate.h
+++ b/FsprgEmbeddedStore/FsprgEmbeddedStoreDelegate.h
@@ -79,4 +79,11 @@ typedef enum {
  */
 - (BOOL)shouldStoreControllerFixContentDivHeight:(FsprgEmbeddedStoreController *)controller;
 
+/*!
+ * Invoked when starting to load a page.
+ * @param sender The web view containing the frame.
+ * @param frame The frame being loaded.
+ */
+- (void)webView:(WebView *)sender didStartProvisionalLoadForFrame:(WebFrame *)frame;
+
 @end


### PR DESCRIPTION
We use this method to show the loading state as soon as possible.